### PR TITLE
feat: update Stability API URL

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -119,7 +119,7 @@ const config: HardhatUserConfig = {
     stability: {
       ...networkConfig,
       // To get a API key, visit https://portal.stabilityprotocol.com
-      url: `https://gtn.stabilityprotocol.com/?api_key=${STABILITY_API_KEY}`,
+      url: `https://gtn.stabilityprotocol.com/zgt/${STABILITY_API_KEY}`,
     },
     /**
      * Polygon


### PR DESCRIPTION
## Summary

The Stability team realized that forwarding a query param in the provider, like our API KEY, has erratic behavior, resulting in the API KEY or related stuff not being forwarded to the Hardhat request. Check related issue here: https://github.com/NomicFoundation/hardhat/issues/3815

This PR updates the Stability RPC URL by avoiding using query parameters for the API KEY.

## Changes
- hardhat.config.ts