### PR TITLE
fix: export Params from utils

### DIFF
--- a/src/utils/encode-init-params.ts
+++ b/src/utils/encode-init-params.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 
-interface Params {
+export interface Params {
   name: string;
   symbol: string;
   deployer: string;


### PR DESCRIPTION
## Summary
Export type `Params` from token-registry as method `encodeInitParams` is exported but it's parameter type `Params` is not previously exported.

## Changes
* What are the changes made in this pull request?
- export type `Params` from token-registry

## Issues
What are the related issues or stories?
https://tradetrust.atlassian.net/browse/TT-127
