### PR TITLE
fix: add contract addresses for XDC and Amoy

### DIFF
--- a/src/constants/contract-address.ts
+++ b/src/constants/contract-address.ts
@@ -30,6 +30,9 @@ export const contractAddress = {
     [ChainId.Polygon]: "0x92470d0Fc33Cbf2f04B39696733806a15eD7eef3",
     [ChainId.StabilityTestnet]: "0xc9A4F6b4f7afAeC816f2CFB715bB92384Fa46BCa",
     [ChainId.Stability]: "0x163A63415d1bf6DeE66B0624e2313fB9127a599b",
+    [ChainId.XDC]: "0xF69B8542a1015c8af590c3aF833A225094aAB57C",
+    [ChainId.XDCApothem]: "0xc435E2B62F10301e3F2905219ee124011A8774C6",
+    [ChainId.PolygonAmoy]: "0x274eF26b068C0E100cD3A9bf39998CAe336c8e1f",
   },
   TokenImplementation: {
     [ChainId.Ethereum]: "0xd3F09dD800525Ecf7e452C3c167C7c716632d016",
@@ -38,5 +41,7 @@ export const contractAddress = {
     [ChainId.PolygonAmoy]: "0xbA351CF5EC041EF661699ab5cfF605850b6Dcd91",
     [ChainId.StabilityTestnet]: "0x6cDc8cD1d9c3f28DC59F5021401687E98bd18740",
     [ChainId.Stability]: "0xc9A4F6b4f7afAeC816f2CFB715bB92384Fa46BCa",
+    [ChainId.XDC]: "0xAfc53249DC017030f73Cc57b18bD460d9d1f27aa",
+    [ChainId.XDCApothem]: "0x79ED245fFecdAF8C87BFE35ccF6A7b9FE9024240",
   },
 };


### PR DESCRIPTION
## Summary
Added addresses of newly deployed TDocDeployer and Implementation for XDC, XDC Apothem and Polygon Amoy
