### PR TITLE
fix: error in `ethers` Version 5 Compatibility Code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tradetrust-tt/token-registry",
-  "version": "5.0.0",
+  "version": "5.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tradetrust-tt/token-registry",
-      "version": "5.0.0",
+      "version": "5.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ethers": "^6.13.4"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
   "name": "@tradetrust-tt/token-registry",
-  "version": "5.0.0",
+  "version": "5.1.1",
   "release": {
     "branches": [
-      { "name": "master" },
-      { "name": "v4", "range": "4.x.x" }
+      {
+        "name": "master"
+      },
+      {
+        "name": "v4",
+        "range": "4.x.x"
+      }
     ],
     "tagFormat": "v${version}"
   },

--- a/src/constants/default-address.ts
+++ b/src/constants/default-address.ts
@@ -1,4 +1,6 @@
-import { ethers } from "ethers";
+import { ethers as packedEthers } from "ethers";
+
+const ethers = { ...packedEthers };
 
 if (ethers.version.includes("/5")) {
   (ethers as any).ZeroAddress = (ethers as any)?.constants?.AddressZero;

--- a/src/constants/role-hash.ts
+++ b/src/constants/role-hash.ts
@@ -1,4 +1,6 @@
-import { ethers } from "ethers";
+import { ethers as packedEthers } from "ethers";
+
+const ethers = { ...packedEthers };
 
 if (ethers.version.includes("/5")) {
   (ethers as any).id = (ethers as any).utils.id;

--- a/src/utils/compute-interface-id.ts
+++ b/src/utils/compute-interface-id.ts
@@ -1,4 +1,6 @@
-import { ethers } from "ethers";
+import { ethers as packedEthers } from "ethers";
+
+const ethers = { ...packedEthers };
 
 if (ethers.version.includes("/5")) {
   (ethers as any).id = (ethers as any).utils.id;

--- a/src/utils/compute-title-escrow-address.ts
+++ b/src/utils/compute-title-escrow-address.ts
@@ -1,4 +1,4 @@
-import { ethers } from "ethers";
+import { ethers as packedEthers } from "ethers";
 
 interface Params {
   implementationAddress: string;
@@ -6,6 +6,8 @@ interface Params {
   registryAddress: string;
   tokenId: string;
 }
+
+const ethers = { ...packedEthers };
 
 if (ethers.version.includes("/5")) {
   (ethers as any).keccak256 = (ethers as any).utils.keccak256;

--- a/src/utils/encode-init-params.ts
+++ b/src/utils/encode-init-params.ts
@@ -1,4 +1,6 @@
-import { ethers } from "ethers";
+import { ethers as packedEthers } from "ethers";
+
+const ethers = { ...packedEthers };
 
 export interface Params {
   name: string;

--- a/src/utils/get-event-from-receipt.ts
+++ b/src/utils/get-event-from-receipt.ts
@@ -1,4 +1,6 @@
-import { ethers } from "ethers";
+import { ethers as packedEthers } from "ethers";
+
+const ethers = { ...packedEthers };
 
 if (ethers.version.includes("/5")) {
   (ethers as any).Interface = (ethers as any).utils.Interface;


### PR DESCRIPTION
## **Summary**
This PR resolves a critical runtime error encountered when attempting to extend the `ethers` object. The error was as follows:


The issue stemmed from the immutability of the `ethers` object imported from the library, which does not allow modifications or extensions of its properties.

---

## **Error:**
```console
Uncaught TypeError: Cannot add property keccak256, object is not extensible
    at assets/index-fca22a90.js (compute-title-escrow-address.js:9:18)
    at __require (index-fca22a90.js:5:52)
    at main.tsx:20:1
```



## **Root Cause**
The previous implementation directly modified the imported `ethers` object to add compatibility features for version 5 of the library. However, objects exported by ES modules are immutable, resulting in the runtime error.

## **Fix**
The updated implementation creates a mutable copy of the ethers object using object spread syntax ({ ...packedEthers }) before extending it. This approach preserves the immutability of the original ethers object while resolving the error.

## **Changes Made**
Replaced direct usage of the immutable ethers object with a mutable copy (const ethers = { ...packedEthers };).
Updated all affected files to ensure consistency across the codebase.

## **Impact**
Error Fixed: Resolved the "Object is Not Extensible" runtime error.
Backward Compatibility: Retains compatibility with ethers version 5.
Code Maintainability: Ensured consistent implementation across multiple files.

## **Testing**
Verified the fix in environments using ethers version 5.
Confirmed that the `computeTitleEscrowAddress`, `computeInterfaceId`, `encodeInitParams`, `getEventFromReceipt`, `roleHash` & `defaultAddress` function performs as expected without errors.


### **Old Code Example**
```typescript
import { ethers } from "ethers";

if (ethers.version.includes("/5")) {
  (ethers as any).keccak256 = (ethers as any).utils.keccak256;
  (ethers as any).solidityPackedKeccak256 = (ethers as any).utils.solidityKeccak256;
  (ethers as any).solidityPacked = (ethers as any).utils.solidityPack;
  (ethers as any).getCreate2Address = (ethers as any).utils.getCreate2Address;
}
```

## **New Code Example**
```typescript
import { ethers as packedEthers } from "ethers";

const ethers = { ...packedEthers };

if (ethers.version.includes("/5")) {
  (ethers as any).keccak256 = (ethers as any).utils.keccak256;
  (ethers as any).solidityPackedKeccak256 = (ethers as any).utils.solidityKeccak256;
  (ethers as any).solidityPacked = (ethers as any).utils.solidityPack;
  (ethers as any).getCreate2Address = (ethers as any).utils.getCreate2Address;
}
```


